### PR TITLE
Added support for passing in a writeable stream as the dest param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 test/all
+/test/allStream.txt

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 var loop = require("serial-loop");
 var fs = require("fs"),
-  stream = require('stream');
+  Stream = require('stream');
 
 module.exports = concat;
 
 function concat (files, dest, callback) {
   
-  var destIsStream = (dest instanceof stream.Writable);
+  var destIsStream = (dest instanceof Stream);
   var wstream = destIsStream ? dest : fs.createWriteStream(dest);
 
   loop(files.length, each, function(){
@@ -21,3 +21,4 @@ function concat (files, dest, callback) {
     rstream.on('end', done);
   }
 }
+

--- a/index.js
+++ b/index.js
@@ -1,22 +1,23 @@
 var loop = require("serial-loop");
-var fs = require("fs");
+var fs = require("fs"),
+  stream = require('stream');
 
 module.exports = concat;
 
 function concat (files, dest, callback) {
-  fs.writeFile(dest, '', function (error) {
-    if (error) return callback(error);
+  
+  var destIsStream = (dest instanceof stream.Writable);
+  var wstream = destIsStream ? dest : fs.createWriteStream(dest);
 
-    loop(files.length, each, callback);
-
-    function each (done, i) {
-      fs.readFile(files[i], function (error, buffer) {
-        if (error) return done(error);
-
-        fs.appendFile(dest, buffer, done);
-      });
-    }
-
+  loop(files.length, each, function(){
+    // Close the stream if this function spawned it
+    if (!destIsStream) wstream.end();
+    callback();
   });
 
+  function each (done, i) {
+    var rstream = fs.createReadStream(files[i]);
+    rstream.pipe(wstream, {end: false});
+    rstream.on('end', done);
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,9 @@
 var concat = require("../");
 var test = require("prova");
-var fs = require("fs");
+var fs = require("fs")
+	stream = require('stream');
+
+var nlChar = require('os').EOL;
 
 test('concat', function (assert) {
   assert.plan(3);
@@ -9,7 +12,25 @@ test('concat', function (assert) {
 
     fs.readFile('./test/all', function (error, all) {
       assert.error(error);
-      assert.equal(all.toString(), 'this is a\nthis is b\nand this is c\n');
+      assert.equal(all.toString(), 'this is a' + nlChar + 'this is b' + nlChar +
+      	'and this is c' + nlChar);
+    });
+  });
+});
+
+test('concat write stream', function (assert) {
+  assert.plan(3);
+
+  var dest = './test/allStream.txt';
+  var wstream = fs.createWriteStream(dest);
+
+  concat(['./test/a', './test/b', './test/c'], wstream, function (error) {
+    assert.error(error);
+    wstream.end();
+    fs.readFile(dest, function (error, all) {
+      assert.error(error);
+      assert.equal(all.toString(), 'this is a' + nlChar + 'this is b' + nlChar +
+      	'and this is c' + nlChar);
     });
   });
 });


### PR DESCRIPTION
In another project this allows me to do something like this in my package.json

`...
"scripts": {
  "build-css": "node build-css.js css > assets/closure.css"
}
...`

And inside the build-css file I can generate my filepaths, call the **concat** package and pipe directly to stdout.
